### PR TITLE
rgw: SignatureDoesNotMatch for certain RGW Admin Ops endpoints w/v4 auth

### DIFF
--- a/src/rgw/rgw_auth_s3.cc
+++ b/src/rgw/rgw_auth_s3.cc
@@ -574,7 +574,7 @@ std::string get_v4_canonical_qs(const req_info& info, const bool using_qs)
 
   /* Handle case when query string exists. Step 3 described in: http://docs.
    * aws.amazon.com/general/latest/gr/sigv4-create-canonical-request.html */
-  std::map<std::string, std::string> canonical_qs_map;
+  std::multimap<std::string, std::string> canonical_qs_map;
   for (const auto& s : get_str_vec<5>(*params, "&")) {
     std::string_view key, val;
     const auto parsed_pair = parse_key_value(s);
@@ -595,7 +595,7 @@ std::string get_v4_canonical_qs(const req_info& info, const bool using_qs)
     // while awsv4 specs ask for all slashes to be encoded, s3 itself is relaxed
     // in its implementation allowing non-url-encoded slashes to be present in
     // presigned urls for instance
-    canonical_qs_map[aws4_uri_recode(key, true)] = aws4_uri_recode(val, true);
+    canonical_qs_map.insert({{aws4_uri_recode(key, true), aws4_uri_recode(val, true)}});
   }
 
   /* Thanks to the early exist we have the guarantee that canonical_qs_map has


### PR DESCRIPTION
In get_v4_canonical_qs() [rgw_auth_s3.cc], change from std::map<> to std::multimap<> to allow for duplicates in the command used to calculate the hash.  rgwadmin submits duplicates in a very few cases, so we need to handle them.

fixes https://tracker.ceph.com/issues/62105

There's been a patch here: https://github.com/UMIACS/rgwadmin/issues/62. Once the patch to ceph is in release, this patch to UMIACS should be reversed.

Signed-off-by: David Hall <davidh@akamai.com>
